### PR TITLE
Add full Google Translate support

### DIFF
--- a/app.js
+++ b/app.js
@@ -411,10 +411,24 @@ function initializeLanguageSelector() {
     const languageSelector = document.getElementById('languageSelector');
     if (languageSelector) {
         languageSelector.addEventListener('change', function() {
-            currentLanguage = this.value;
-            translateInterface();
+            translatePage(this.value);
         });
     }
+}
+
+function setCookie(name, value, days) {
+    const date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    const expires = 'expires=' + date.toUTCString();
+    document.cookie = name + '=' + value + ';' + expires + ';path=/';
+}
+
+function translatePage(lang) {
+    const map = { 'en': '/en/en', 'es': '/en/es', 'pt': '/en/pt' };
+    setCookie('googtrans', map[lang] || '/en/en', 1);
+    currentLanguage = lang;
+    translateInterface();
+    location.reload();
 }
 
 function translateInterface() {

--- a/index.html
+++ b/index.html
@@ -476,6 +476,13 @@
         </div>
     </div>
 
+    <div id="google_translate_element" style="display:none"></div>
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'en,es,pt'}, 'google_translate_element');
+        }
+    </script>
+    <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Google Translate widget so the whole site can be translated
- hook language dropdown to update the Google Translate language cookie

## Testing
- `node test.js` *(fails: Cannot find module '@prisma/client')*
- `npm install @prisma/client` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687a710ec2708323aef6ba0efb83b6a4