### PR TITLE
Integrate WebRTC demo into Calls tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ This repository contains a prototype of the Feelynx platform. A simple WebRTC de
    npm start
    ```
    This launches a WebSocket server on `ws://localhost:8080`.
-3. Open `webrtc.html` in two separate browser windows. Press **Start Call** in one of them to begin a peer‑to‑peer connection. Allow camera and microphone permissions when prompted.
+3. Open `index.html` (or `webrtc.html`) in two separate browser windows. Navigate to the **Calls** tab and press **Start Call** in one of them to begin a peer‑to‑peer connection. Allow camera and microphone permissions when prompted.
 
-The demo uses a basic WebSocket signaling server and `RTCPeerConnection` with Google's public STUN server.
+The demo uses a basic WebSocket signaling server and `RTCPeerConnection` with Google's public STUN server. The `Calls` tab on the main site now embeds the same WebRTC demo.

--- a/index.html
+++ b/index.html
@@ -228,6 +228,14 @@
                     <div class="call-creators" id="callCreators">
                         <p class="no-js-fallback">Creators loading...</p>
                     </div>
+
+                    <div class="webrtc-demo">
+                        <button id="startCall">Start Call</button>
+                        <div id="videos">
+                            <video id="localVideo" autoplay muted></video>
+                            <video id="remoteVideo" autoplay></video>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -507,6 +515,7 @@
         }
     </script>
     <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <script src="webrtc.js"></script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2935,3 +2935,22 @@ img[alt="Feelynx Mascot"] {
   display: inline-block;
   text-shadow: 0 2px 8px rgba(255, 95, 109, 0.13);
 }
+
+/* WebRTC demo elements */
+.webrtc-demo #videos {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.webrtc-demo video {
+  width: 45%;
+  margin: 5px;
+  background: #000;
+}
+
+#startCall {
+  display: block;
+  margin: 20px auto;
+  padding: 10px 20px;
+}


### PR DESCRIPTION
## Summary
- embed WebRTC demo elements inside the Calls tab
- load `webrtc.js` on the main page
- style videos and button
- update README with updated instructions

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687abcd2d7088323bd4825b494bf1d3a