### PR TITLE
Load Firebase credentials from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+FIREBASE_API_KEY=your-api-key
+FIREBASE_AUTH_DOMAIN=your-auth-domain
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_STORAGE_BUCKET=your-storage-bucket
+FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+FIREBASE_APP_ID=your-app-id
+FIREBASE_MEASUREMENT_ID=your-measurement-id

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 This repository contains a prototype of the Feelynx platform. A simple WebRTC demonstration is included for testing audio/video calls.
 
 ## Running the demo
-1. Install dependencies:
+1. Copy `.env.example` to `.env` and fill in your Firebase credentials.
+2. Install dependencies:
    ```bash
    npm install
    ```
-2. Start the signaling server:
+3. Start the signaling server:
    ```bash
    npm start
    ```
    This launches a WebSocket server on `ws://localhost:8080`.
-3. Open `index.html` (or `webrtc.html`) in two separate browser windows. Navigate to the **Calls** tab and press **Start Call** in one of them to begin a peer‑to‑peer connection. Allow camera and microphone permissions when prompted.
+4. Open `index.html` (or `webrtc.html`) in two separate browser windows. Navigate to the **Calls** tab and press **Start Call** in one of them to begin a peer‑to‑peer connection. Allow camera and microphone permissions when prompted.
 
 The demo uses a basic WebSocket signaling server and `RTCPeerConnection` with Google's public STUN server. The `Calls` tab on the main site now embeds the same WebRTC demo.

--- a/firebase.js
+++ b/firebase.js
@@ -2,15 +2,16 @@
 
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
+import 'dotenv/config';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyDrF7YbK-NHSALJfFfrQGobnDXDuVH0KE",
-  authDomain: "feelynx-47c57.firebaseapp.com",
-  projectId: "feelynx-47c57",
-  storageBucket: "feelynx-47c57.appspot.com",
-  messagingSenderId: "132290937381",
-  appId: "1:132290937381:web:0493a870311b376e0035cc",
-  measurementId: "G-T194B2JR6R"
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID,
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID,
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- move Firebase creds to environment variables
- document new `.env` setup
- ignore local `.env` files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b1209d1c48323af548d182edd967e