### PR TITLE
Make WebSocket server port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This repository contains a prototype of the Feelynx platform. A simple WebRTC de
    ```bash
    npm install
    ```
-3. Start the signaling server:
+3. Start the signaling server (optionally set `PORT` to override the default 8080):
    ```bash
-   npm start
+   PORT=3000 npm start
    ```
-   This launches a WebSocket server on `ws://localhost:8080`.
+   By default this launches a WebSocket server on `ws://localhost:8080`.
 4. Open `index.html` (or `webrtc.html`) in two separate browser windows. Navigate to the **Calls** tab and press **Start Call** in one of them to begin a peer‑to‑peer connection. Allow camera and microphone permissions when prompted.
 
 The demo uses a basic WebSocket signaling server and `RTCPeerConnection` with Google's public STUN server. The `Calls` tab on the main site now embeds the same WebRTC demo.

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const WebSocket = require('ws');
 
-const wss = new WebSocket.Server({ port: 8080 });
+const port = process.env.PORT || 8080;
+const wss = new WebSocket.Server({ port });
 
 wss.on('connection', ws => {
   ws.on('message', message => {
@@ -13,4 +14,4 @@ wss.on('connection', ws => {
   });
 });
 
-console.log('WebSocket signaling server running on ws://localhost:8080');
+console.log(`WebSocket signaling server running on ws://localhost:${port}`);


### PR DESCRIPTION
## Summary
- allow setting the port via `PORT` environment variable
- document how to set `PORT` before running the server

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687fab92ed908323b1fd7c38dffeea8f