### PR TITLE
UI improvements for streaming demo

### DIFF
--- a/feelynx-coins.html
+++ b/feelynx-coins.html
@@ -30,11 +30,28 @@
       flex-direction: column;
       align-items: center;
       margin-bottom: 0;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    .coins-card:hover {
+      transform: translateY(-4px) scale(1.03);
+      box-shadow: 0 10px 30px rgba(162,89,255,0.4);
     }
     .pack-name { font-size: 1.1rem; color: #fff; font-weight: 600; letter-spacing: 0.03em; }
     .pack-price { font-size: 1.2rem; font-weight: 700; color: #f6b556; margin: 0.8rem 0 0.6rem 0; }
     .pack-coins { font-size: 2.1rem; font-weight: 800; color: #ff6ec7; margin-bottom: 0.7rem; }
     .web-extra { font-size: 0.98rem; color: #9ae3ff; margin-bottom: 1.1rem; }
+    .bonus-badge {
+      background: #f35369;
+      color: #fff;
+      font-size: 0.75rem;
+      padding: 2px 6px;
+      border-radius: 4px;
+      animation: pulse 2s infinite;
+    }
+    @keyframes pulse {
+      0%,100% { box-shadow: 0 0 0 0 rgba(243,83,105,0.7); }
+      50% { box-shadow: 0 0 0 10px rgba(243,83,105,0); }
+    }
     .buy-coins-btn {
       background: linear-gradient(90deg,#ff6ec7,#61e5ff 99%);
       color: #fff;
@@ -93,7 +110,7 @@
           <div class="pack-price">$${pack.price}</div>
           <div class="pack-coins">${pack.webTokens} <span class="icon-coin" aria-label="coins" role="img">🪙</span></div>
           <div class="app-coins">${pack.appTokens} coins in app</div>
-          <span class="web-extra">+${pack.bonusPercent}% More On Web</span>
+          <span class="web-extra bonus-badge">+${pack.bonusPercent}% More On Web</span>
           <button class="buy-coins-btn">Buy Now</button>
         </div>
       `).join('');

--- a/lovense.js
+++ b/lovense.js
@@ -1,31 +1,48 @@
-// Basic Lovense integration using the local Lovense Connect API
-// Assumes Lovense Connect is running on the same machine (default port 30010)
-// Exposes global `lovense` object with helper methods
+// Lovense integration helpers
+// Provides pair(), startVibration() and stopVibration() with basic UI feedback.
 
 const LOVENSE_URL = 'http://localhost:30010';
+let paired = false;
+const statusIcon = document.getElementById('vibeStatusIcon');
 
 async function connectLovense() {
+  const res = await fetch(`${LOVENSE_URL}/GetToys`).catch(() => null);
+  if (!res || !res.ok) throw new Error('No toys detected');
+  const data = await res.json();
+  console.log('Connected toys:', data);
+  return data;
+}
+
+async function pair() {
   try {
-    const res = await fetch(`${LOVENSE_URL}/GetToys`);
-    if (!res.ok) throw new Error('No toys detected');
-    const data = await res.json();
-    console.log('Connected toys:', data);
-    return data;
-  } catch (err) {
-    console.error('Failed to connect to Lovense Connect:', err);
+    await connectLovense();
+    paired = true;
+  } catch (e) {
+    console.error('Failed to connect to Lovense Connect:', e);
+    paired = false;
   }
 }
 
 async function vibrateToy(device = 'all', level = 1, time = 5) {
+  await fetch(`${LOVENSE_URL}/Vibrate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ device, level, time })
+  });
+}
+
+async function startVibration(level = 1, time = 5) {
+  if (!paired) return;
+  statusIcon?.classList.add('animate-pulse', 'text-pink-500');
   try {
-    await fetch(`${LOVENSE_URL}/Vibrate`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ device, level, time })
-    });
-  } catch (err) {
-    console.error('Failed to send vibration command:', err);
+    await vibrateToy('all', level, time);
+  } finally {
+    statusIcon?.classList.remove('animate-pulse', 'text-pink-500');
   }
 }
 
-window.lovense = { connectLovense, vibrateToy };
+function stopVibration() {
+  statusIcon?.classList.remove('animate-pulse', 'text-pink-500');
+}
+
+window.lovense = { pair, startVibration, stopVibration };

--- a/webrtc.html
+++ b/webrtc.html
@@ -2,21 +2,42 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Feelynx WebRTC Demo</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
-  <style>
-    video { width: 45%; margin: 5px; background: #000; }
-    #videos { display: flex; justify-content: center; margin-top: 20px; }
-    #startCall { display: block; margin: 20px auto; padding: 10px 20px; }
-  </style>
 </head>
 <body>
-  <h1 style="text-align:center">WebRTC Demo</h1>
-  <button id="startCall">Start Call</button>
-  <div id="videos">
-    <video id="localVideo" autoplay muted></video>
-    <video id="remoteVideo" autoplay></video>
+  <div class="min-h-screen bg-gray-900 text-gray-100 flex flex-col items-center py-8">
+    <h1 class="text-3xl font-bold mb-6 text-pink-400">WebRTC Demo</h1>
+
+    <!-- Call state indicator -->
+    <p id="callState" class="mb-1">Waiting</p>
+    <div class="mb-4 text-xl" id="vibeStatusIcon" title="Toy status">💜</div>
+
+    <!-- Videos -->
+    <div id="videos" class="flex flex-wrap justify-center space-x-2 mb-4">
+      <video id="localVideo" class="bg-black rounded w-64 md:w-80" autoplay muted></video>
+      <video id="remoteVideo" class="bg-black rounded w-64 md:w-80" autoplay></video>
+    </div>
+
+    <!-- Controls -->
+    <div class="flex space-x-3">
+      <button id="startCall" class="px-4 py-2 bg-pink-600 rounded text-white hover:bg-pink-500">Start Call</button>
+      <button id="muteButton" class="px-4 py-2 bg-purple-600 rounded text-white hidden" title="Mute/unmute audio">Mute</button>
+      <button id="endCall" class="px-4 py-2 bg-gray-700 rounded text-white hidden" title="End call">End</button>
+    </div>
   </div>
+
+  <!-- Onboarding Modal -->
+  <div id="permissionModal" class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center hidden">
+    <div class="bg-gray-800 p-6 rounded text-center">
+      <p class="mb-4">Allow camera and microphone access to start the call.</p>
+      <button id="allowPermissions" class="px-4 py-2 bg-pink-600 rounded text-white mr-2">Allow</button>
+      <button id="denyPermissions" class="px-4 py-2 bg-gray-700 rounded text-white">Cancel</button>
+    </div>
+  </div>
+
   <script src="lovense.js"></script>
   <script src="webrtc.js"></script>
 </body>

--- a/webrtc.js
+++ b/webrtc.js
@@ -1,25 +1,53 @@
-let localVideo = document.getElementById('localVideo') || document.getElementById('broadcastVideo');
+// Enhanced WebRTC demo with basic call controls and Lovense integration
+// This script handles UI states and peer connection setup.
+
+const localVideo = document.getElementById('localVideo');
 const remoteVideo = document.getElementById('remoteVideo');
-const startButtons = Array.from(document.querySelectorAll('#startCall, #startBroadcast'));
+const startBtn = document.getElementById('startCall');
+const muteBtn = document.getElementById('muteButton');
+const endBtn = document.getElementById('endCall');
+const callStateEl = document.getElementById('callState');
+const allowBtn = document.getElementById('allowPermissions');
+const denyBtn = document.getElementById('denyPermissions');
+const permissionModal = document.getElementById('permissionModal');
+
 const ws = new WebSocket('ws://localhost:8080');
 let pc;
 let localStream;
+let muted = false;
 
-// Listen for signaling messages over WebSocket and establish the peer connection
+function setState(state) {
+  if (callStateEl) callStateEl.textContent = state;
+}
+
+// ----- Peer connection helpers -----
+async function createPeer() {
+  pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+  pc.onicecandidate = ({ candidate }) => {
+    if (candidate) ws.send(JSON.stringify({ candidate }));
+  };
+  pc.ontrack = (event) => {
+    remoteVideo.srcObject = event.streams[0];
+    setState('Call in progress');
+    // Vibrate toy when the call starts
+    window.lovense?.startVibration?.();
+  };
+  if (localStream) {
+    localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
+  }
+}
+
 ws.addEventListener('message', async event => {
   const data = JSON.parse(event.data);
   if (!pc) await createPeer();
   if (data.offer) {
-    // Received an SDP offer from the remote peer: set as remote and send answer
     await pc.setRemoteDescription(data.offer);
     const answer = await pc.createAnswer();
     await pc.setLocalDescription(answer);
     ws.send(JSON.stringify({ answer }));
   } else if (data.answer) {
-    // Received the answer to our offer: simply set it as remote description
     await pc.setRemoteDescription(data.answer);
   } else if (data.candidate) {
-    // Add incoming ICE candidates to the peer connection
     try {
       await pc.addIceCandidate(data.candidate);
     } catch (e) {
@@ -28,50 +56,57 @@ ws.addEventListener('message', async event => {
   }
 });
 
-// Creates the RTCPeerConnection and wire up event handlers
-async function createPeer() {
-  pc = new RTCPeerConnection({
-    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
-  });
-  // Send ICE candidates to the remote peer over the signaling channel
-  pc.onicecandidate = ({ candidate }) => {
-    if (candidate) ws.send(JSON.stringify({ candidate }));
-  };
-  // When a remote track arrives, display it and trigger the Lovense device
-  pc.ontrack = (event) => {
-    if (remoteVideo) {
-      remoteVideo.srcObject = event.streams[0];
-    }
-    // Kick off a vibration if the Lovense integration is available
-    if (window.lovense) {
-      // call vibrateToy and handle any errors
-      Promise.resolve(window.lovense.vibrateToy())
-        .catch((err) => console.error('Lovense vibration error:', err));
-    }
-  };
-  // Add our local media tracks to the connection
-  if (localStream) {
-    localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
-  }
+function resetUI() {
+  startBtn.classList.remove('hidden');
+  muteBtn.classList.add('hidden');
+  endBtn.classList.add('hidden');
+  setState('Call ended');
+  window.lovense?.stopVibration?.();
 }
 
-// Handle click on any "Start" button
-startButtons.forEach(btn => btn.addEventListener('click', async () => {
-  localVideo = document.getElementById('localVideo') || document.getElementById('broadcastVideo');
-  // Connect to Lovense first if available
-  if (window.lovense) {
-    try {
-      await window.lovense.connectLovense();
-    } catch (err) {
-      console.error('Lovense connection error:', err);
-    }
+// ----- Button handlers -----
+startBtn.addEventListener('click', () => {
+  permissionModal.classList.remove('hidden');
+});
+
+denyBtn.addEventListener('click', () => {
+  permissionModal.classList.add('hidden');
+});
+
+allowBtn.addEventListener('click', async () => {
+  permissionModal.classList.add('hidden');
+  setState('Connecting...');
+  try {
+    // Attempt to pair Lovense toy first
+    await window.lovense?.pair?.();
+    localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    localVideo.srcObject = localStream;
+    muteBtn.classList.remove('hidden');
+    endBtn.classList.remove('hidden');
+    startBtn.classList.add('hidden');
+    await createPeer();
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    ws.send(JSON.stringify({ offer }));
+    setState('Waiting for peer...');
+  } catch (err) {
+    console.error(err);
+    setState('Error starting call');
   }
-  // Get access to the user's camera and microphone
-  localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
-  localVideo.srcObject = localStream;
-  // Initialize peer connection and create/send an offer
-  await createPeer();
-  const offer = await pc.createOffer();
-  await pc.setLocalDescription(offer);
-  ws.send(JSON.stringify({ offer }));
-}));
+});
+
+endBtn.addEventListener('click', () => {
+  pc?.close();
+  localStream?.getTracks().forEach(t => t.stop());
+  resetUI();
+});
+
+muteBtn.addEventListener('click', () => {
+  if (!localStream) return;
+  muted = !muted;
+  localStream.getAudioTracks().forEach(t => (t.enabled = !muted));
+  muteBtn.textContent = muted ? 'Unmute' : 'Mute';
+});
+
+// Expose a helper for other scripts/tests
+window.webrtcDemo = { resetUI };


### PR DESCRIPTION
## Summary
- revamp WebRTC demo UI with TailwindCSS
- add permission modal, call states and control buttons
- implement Lovense pairing and vibration helpers
- animate token store cards and highlight bonuses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882932b1d6083239f77fe72cee8cd09