### PR TITLE
Add Go Live floating button with React modal

### DIFF
--- a/feelynx-coins.html
+++ b/feelynx-coins.html
@@ -6,6 +6,7 @@
   <title>Buy Vibecoins – Feelynx</title>
   <link rel="stylesheet" href="feelynx-coins.css">
   <link rel="stylesheet" href="style.css">
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <style>
     /* --- 3x3 Responsive Grid Styles --- */
     .coins-packages-container {
@@ -116,5 +117,9 @@
       `).join('');
     });
   </script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" src="goLiveButton.js"></script>
 </body>
 </html>

--- a/goLiveButton.js
+++ b/goLiveButton.js
@@ -1,0 +1,91 @@
+const { useState, useEffect } = React;
+
+function GoLiveWidget() {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('general');
+  const [camera, setCamera] = useState(true);
+  const [microphone, setMicrophone] = useState(true);
+
+  const openModal = () => setOpen(true);
+  const closeModal = () => setOpen(false);
+
+  return (
+    <>
+      <div className="fixed bottom-6 right-6 z-50">
+        <button
+          onClick={openModal}
+          className="bg-gradient-to-br from-pink-500 to-purple-600 hover:from-pink-400 hover:to-purple-500 text-white font-bold py-3 px-6 rounded-full shadow-lg focus:outline-none focus:ring-4 focus:ring-pink-300 animate-pulse"
+        >
+          Go Live
+        </button>
+      </div>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+          onClick={closeModal}
+        >
+          <div
+            className="bg-white rounded-lg p-6 w-11/12 max-w-sm transform transition-all duration-300"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-semibold">Start Live Stream</h2>
+              <button onClick={closeModal} className="text-gray-500 text-2xl leading-none">&times;</button>
+            </div>
+            <div className="space-y-4">
+              <input
+                className="w-full border rounded px-3 py-2"
+                placeholder="Stream Title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
+              <select
+                className="w-full border rounded px-3 py-2"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+              >
+                <option value="general">General</option>
+                <option value="gaming">Gaming</option>
+                <option value="chatting">Chatting</option>
+                <option value="music">Music</option>
+              </select>
+              <div className="flex items-center space-x-4">
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={camera}
+                    onChange={(e) => setCamera(e.target.checked)}
+                  />
+                  Camera
+                </label>
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={microphone}
+                    onChange={(e) => setMicrophone(e.target.checked)}
+                  />
+                  Microphone
+                </label>
+              </div>
+              <button
+                className="w-full bg-gradient-to-br from-pink-500 to-purple-600 hover:from-pink-400 hover:to-purple-500 text-white py-2 rounded-lg shadow"
+              >
+                Start Stream
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  ReactDOM.render(<GoLiveWidget />, container);
+});

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Feelynx – Premium Adult Entertainment Platform</title>
     <link rel="stylesheet" href="style.css">
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <!-- Add Google Fonts here -->
     <link href="https://fonts.googleapis.com/css?family=Playfair+Display:700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:600&display=swap" rel="stylesheet">
@@ -528,5 +529,9 @@
     <script src="webrtc.js"></script>
     <script src="coinPackages.js"></script>
     <script src="app.js"></script>
+    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" src="goLiveButton.js"></script>
 </body>
 </html>

--- a/webrtc.html
+++ b/webrtc.html
@@ -40,5 +40,9 @@
 
   <script src="lovense.js"></script>
   <script src="webrtc.js"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" src="goLiveButton.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Tailwind CDN to HTML pages
- include React and Babel scripts
- implement `goLiveButton.js` React component
- show floating "Go Live" button and modal across pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688315524468832382c77cd1ed1bf87e