### PR TITLE
Enhance server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ the project root. Open this file directly in your browser (e.g.
 `file:///path/to/feelynx-coins.html`) or, if you are serving the repository with
 a local web server, navigate to `/feelynx-coins.html`. The page lists available
 coin bundles and acts as a prototype checkout screen.
+
+## Production Configuration
+
+The server uses environment variables loaded from a `.env` file. For a
+production deployment, ensure that `PORT` is set and any Firebase credentials
+are provided. The server now applies basic security headers with `helmet` and
+rate limiting via `express-rate-limit`. A simple health check endpoint is
+available at `/health`.
+
+Run the server in production mode with:
+
+```bash
+NODE_ENV=production npm start
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.0.0",
+        "helmet": "^7.0.0",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -1412,6 +1415,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1613,6 +1628,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-glob": {
@@ -1864,6 +1894,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.19.2",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "dotenv": "^16.4.5",
+    "helmet": "^7.0.0",
+    "express-rate-limit": "^7.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",

--- a/server.js
+++ b/server.js
@@ -1,9 +1,20 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const WebSocket = require('ws');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 
 const port = process.env.PORT || 8080;
 const app = express();
+app.use(helmet());
+
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
+app.use(limiter);
+
+app.get('/health', (req, res) => {
+  res.send('ok');
+});
 
 // Serve static files from the project root so index.html works out of the box
 app.use(express.static(path.join(__dirname)));


### PR DESCRIPTION
## Summary
- secure server with `helmet` and rate limiting
- support `.env` configuration via dotenv
- add `/health` endpoint
- document production configuration in the README

## Testing
- `npm install --package-lock-only`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68832256329c832390f5d7dd35718391