### PR TITLE
Add pages with streaming and content features

### DIFF
--- a/src/components/CallInterface.tsx
+++ b/src/components/CallInterface.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  creator: { username: string };
+  onEnd: () => void;
+  rate: number;
+}
+
+const CallInterface: React.FC<Props> = ({ creator, onEnd, rate }) => {
+  const [seconds, setSeconds] = useState(0);
+  const intervalRef = useRef<number>();
+
+  useEffect(() => {
+    intervalRef.current = window.setInterval(() => {
+      setSeconds((s) => s + 1);
+    }, 1000);
+    return () => clearInterval(intervalRef.current);
+  }, []);
+
+  const cost = ((seconds / 60) * rate).toFixed(2);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-80 flex flex-col items-center justify-center z-50">
+      <div className="bg-gray-900 p-4 rounded text-center space-y-2 w-80">
+        <div className="bg-gray-700 h-40 flex items-center justify-center rounded">Remote Video</div>
+        <div className="bg-gray-700 h-20 flex items-center justify-center rounded">Local Video</div>
+        <div className="text-sm">Time: {seconds}s • Cost: ${cost}</div>
+        <button className="bg-red-600 w-full py-1 rounded" onClick={onEnd}>End Call</button>
+      </div>
+    </div>
+  );
+};
+
+export default CallInterface;

--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+interface Message {
+  id: number;
+  author: string;
+  text: string;
+}
+
+const ChatBox: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [value, setValue] = useState('');
+
+  const send = () => {
+    if (!value) return;
+    setMessages([...messages, { id: messages.length + 1, author: 'me', text: value }]);
+    setValue('');
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-auto space-y-1 p-2">
+        {messages.map((m) => (
+          <div key={m.id} className="text-sm">
+            <span className="font-semibold mr-1">{m.author}:</span>
+            {m.text}
+          </div>
+        ))}
+      </div>
+      <div className="flex border-t border-gray-700">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && send()}
+          className="flex-1 bg-gray-800 p-1 text-sm"
+          placeholder="Type message"
+        />
+        <button className="px-3 bg-pink-500" onClick={send}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ChatBox;

--- a/src/components/GroupCard.tsx
+++ b/src/components/GroupCard.tsx
@@ -9,7 +9,7 @@ interface Group {
 }
 
 const GroupCard: React.FC<{ group: Group }> = ({ group }) => (
-  <div className="relative bg-gray-800 rounded-lg p-2">
+  <a href={`/groups/${group.id}`} className="relative bg-gray-800 rounded-lg p-2 block hover:shadow-lg">
     <img src={group.thumbnail} alt={group.name} className="rounded" />
     {group.live && (
       <div className="absolute top-2 left-2 bg-red-500 text-xs px-1 rounded">
@@ -18,10 +18,8 @@ const GroupCard: React.FC<{ group: Group }> = ({ group }) => (
     )}
     <div className="mt-2 text-sm font-semibold">{group.name}</div>
     <div className="text-xs text-gray-400">{group.members} members</div>
-    <button className="mt-2 w-full bg-pink-500 text-white py-1 rounded text-sm">
-      Open
-    </button>
-  </div>
+    <button className="mt-2 w-full bg-pink-500 text-white py-1 rounded text-sm">Open</button>
+  </a>
 );
 
 export default GroupCard;

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,14 +1,17 @@
 import React, { useState } from 'react';
+import TipModal from './TipModal';
 
 export interface Post {
   id: number;
   type: 'image' | 'video';
   src: string;
   locked: boolean;
+  price?: number;
 }
 
 const PostCard: React.FC<{ post: Post }> = ({ post }) => {
   const [unlocked, setUnlocked] = useState(!post.locked);
+  const [showTip, setShowTip] = useState(false);
 
   return (
     <div className="bg-gray-800 rounded-lg overflow-hidden">
@@ -18,20 +21,24 @@ const PostCard: React.FC<{ post: Post }> = ({ post }) => {
         <video controls className={unlocked ? '' : 'blur-sm'} src={post.src} />
       )}
       {!unlocked && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center bg-black bg-opacity-50">
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-black bg-opacity-50 space-y-2">
           <button
             onClick={() => setUnlocked(true)}
             className="bg-pink-500 text-white px-3 py-1 rounded"
           >
-            Subscribe to view
+            {post.price ? `Unlock for $${post.price}` : 'Subscribe to view'}
           </button>
         </div>
       )}
       <div className="p-2 flex space-x-4 text-sm">
-        <button>Like</button>
-        <button>Comment</button>
-        <button>Tip</button>
+        <button className="hover:text-pink-400">Like</button>
+        <button className="hover:text-pink-400">Comment</button>
+        <button className="hover:text-pink-400">Repost</button>
+        <button className="hover:text-pink-400" onClick={() => setShowTip(true)}>
+          Tip
+        </button>
       </div>
+      <TipModal open={showTip} onClose={() => setShowTip(false)} />
     </div>
   );
 };

--- a/src/components/StreamCard.tsx
+++ b/src/components/StreamCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface Stream {
   id: number;
@@ -6,22 +6,41 @@ interface Stream {
   viewers: number;
   avatar: string;
   featured?: boolean;
+  isNew?: boolean;
 }
 
 const StreamCard: React.FC<{ stream: Stream }> = ({ stream }) => {
+  const [preview, setPreview] = useState(false);
+
   return (
     <a
       href={`/live/${stream.username}`}
-      className="relative block bg-gray-800 rounded-lg p-2 cursor-pointer hover:shadow-lg"
+      className="relative block bg-gray-800 rounded-lg p-2 cursor-pointer hover:shadow-lg overflow-hidden"
+      onMouseEnter={() => setPreview(true)}
+      onMouseLeave={() => setPreview(false)}
+      onFocus={() => setPreview(true)}
+      onBlur={() => setPreview(false)}
     >
-      <img src={stream.avatar} alt={stream.username} className="rounded" />
+      <img src={stream.avatar} alt={stream.username} className="rounded w-full" />
+      {preview && (
+        <div className="absolute inset-0 bg-black bg-opacity-70 flex items-center justify-center text-xs">
+          <video
+            src="https://www.w3schools.com/html/mov_bbb.mp4"
+            autoPlay
+            loop
+            muted
+            className="w-full h-full object-cover"
+          />
+        </div>
+      )}
       <div className="absolute top-2 left-2 bg-red-500 text-xs px-1 rounded">
         {stream.viewers} watching
       </div>
       {stream.featured && (
-        <div className="absolute top-2 right-2 bg-yellow-500 text-xs px-1 rounded">
-          Featured
-        </div>
+        <div className="absolute top-2 right-2 bg-yellow-500 text-xs px-1 rounded">Featured</div>
+      )}
+      {stream.isNew && !stream.featured && (
+        <div className="absolute top-2 right-2 bg-green-500 text-xs px-1 rounded">New</div>
       )}
       <button className="absolute bottom-2 right-2 bg-pink-500 text-white px-2 py-1 rounded text-xs">
         Join

--- a/src/components/TipModal.tsx
+++ b/src/components/TipModal.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface TipModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const packs = [5, 10, 20, 50];
+
+const TipModal: React.FC<TipModalProps> = ({ open, onClose }) => {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50">
+      <div className="bg-gray-900 p-4 rounded-lg w-72 text-center">
+        <h2 className="text-lg mb-2">Send Tip</h2>
+        <div className="space-y-2">
+          {packs.map((p) => (
+            <button
+              key={p}
+              className="w-full bg-pink-500 py-1 rounded text-white hover:bg-pink-600"
+            >
+              {p} Coins
+            </button>
+          ))}
+        </div>
+        <button
+          className="mt-4 text-sm text-gray-400 hover:text-white"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TipModal;

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import CallCard from '../components/CallCard';
+import CallInterface from '../components/CallInterface';
 
 const mockCallCreators = [
   { id: 1, username: 'creator1', avatar: 'https://placekitten.com/220/200', rate: 2.5 },
@@ -8,11 +9,24 @@ const mockCallCreators = [
 
 const Calls: React.FC = () => {
   const [creators] = useState(mockCallCreators);
+  const [active, setActive] = useState<typeof mockCallCreators[0] | null>(null);
+
   return (
-    <div className="p-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-      {creators.map(c => (
-        <CallCard key={c.id} creator={c} />
-      ))}
+    <div className="p-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {creators.map((c) => (
+          <div key={c.id} onClick={() => setActive(c)}>
+            <CallCard creator={c} />
+          </div>
+        ))}
+      </div>
+      {active && (
+        <CallInterface
+          creator={active}
+          rate={active.rate}
+          onEnd={() => setActive(null)}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/Content.tsx
+++ b/src/pages/Content.tsx
@@ -4,8 +4,8 @@ import type { Post } from '../components/PostCard';
 
 const mockPosts: Post[] = [
   { id: 1, type: 'image', src: 'https://placekitten.com/400/300', locked: false },
-  { id: 2, type: 'video', src: 'https://www.w3schools.com/html/mov_bbb.mp4', locked: true },
-  { id: 3, type: 'image', src: 'https://placekitten.com/401/300', locked: true },
+  { id: 2, type: 'video', src: 'https://www.w3schools.com/html/mov_bbb.mp4', locked: true, price: 5 },
+  { id: 3, type: 'image', src: 'https://placekitten.com/401/300', locked: true, price: 3 },
 ];
 
 const Content: React.FC = () => {

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -3,7 +3,7 @@ import StreamCard from '../components/StreamCard';
 
 const mockStreams = [
   { id: 1, username: 'creator1', viewers: 340, avatar: 'https://placekitten.com/200/200', featured: true },
-  { id: 2, username: 'creator2', viewers: 120, avatar: 'https://placekitten.com/201/200', featured: false },
+  { id: 2, username: 'creator2', viewers: 120, avatar: 'https://placekitten.com/201/200', featured: false, isNew: true },
   { id: 3, username: 'creator3', viewers: 999, avatar: 'https://placekitten.com/202/200', featured: true },
 ];
 

--- a/src/pages/groups/[id].tsx
+++ b/src/pages/groups/[id].tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import ChatBox from '../../components/ChatBox';
+import PostCard from '../../components/PostCard';
+import type { Post } from '../../components/PostCard';
+
+const posts: Post[] = [
+  { id: 1, type: 'image', src: 'https://placekitten.com/420/300', locked: false },
+  { id: 2, type: 'image', src: 'https://placekitten.com/421/300', locked: false },
+];
+
+const GroupPage: React.FC = () => {
+  const id = typeof window !== 'undefined' ? window.location.pathname.split('/').pop() : '';
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Group {id}</h1>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="md:col-span-2 space-y-4">
+          {posts.map((p) => (
+            <PostCard key={p.id} post={p} />
+          ))}
+        </div>
+        <div className="flex flex-col space-y-2">
+          <div className="flex-1 bg-gray-800 rounded overflow-hidden">
+            <ChatBox />
+          </div>
+          <button className="bg-pink-500 rounded py-1">Schedule Stream</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupPage;

--- a/src/pages/live/[username].tsx
+++ b/src/pages/live/[username].tsx
@@ -1,24 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
 import VideoGrid from '../../components/VideoGrid';
+import ChatBox from '../../components/ChatBox';
+import TipModal from '../../components/TipModal';
 
 const LivePage: React.FC = () => {
   const username =
     typeof window !== 'undefined'
       ? window.location.pathname.split('/').pop()
       : '';
+  const [showTip, setShowTip] = useState(false);
 
   return (
     <div className="p-4">
       <h1 className="text-xl mb-4">Live with {username}</h1>
       <div className="grid md:grid-cols-3 gap-4">
         <div className="md:col-span-2">
-          <VideoGrid count={6} />
-        </div>
+          <VideoGrid count={9} />
+          </div>
         <div className="flex flex-col space-y-2">
-          <div className="flex-1 bg-gray-800 rounded p-2 overflow-auto">Chat</div>
-          <div className="bg-gray-800 rounded p-2">Tipping UI</div>
+          <div className="flex-1 bg-gray-800 rounded overflow-hidden">
+            <ChatBox />
+          </div>
+          <button className="bg-pink-500 rounded py-1" onClick={() => setShowTip(true)}>
+            Send Gift
+          </button>
         </div>
       </div>
+      <TipModal open={showTip} onClose={() => setShowTip(false)} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- overhaul stream card with preview video and badges
- implement tip modal, chat box, and call interface components
- extend post card to support unlock pricing and tipping modal
- show dynamic call interface on Calls page
- add multi-guest live page with chat and gifting
- include sample group subpage

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688322aeb5b483239635d9df8d8dd889