### PR TITLE
Add streaming and subscription components

### DIFF
--- a/src/components/CallSession.tsx
+++ b/src/components/CallSession.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface CallSessionProps {
+  creatorName: string;
+  ratePerMinute: number;
+  onEnd?: () => void;
+}
+
+const CallSession: React.FC<CallSessionProps> = ({ creatorName, ratePerMinute, onEnd }) => {
+  const [seconds, setSeconds] = useState(0);
+  const intervalRef = useRef<number>();
+
+  useEffect(() => {
+    intervalRef.current = window.setInterval(() => {
+      setSeconds((s) => s + 1);
+    }, 1000);
+    return () => clearInterval(intervalRef.current);
+  }, []);
+
+  const cost = ((seconds / 60) * ratePerMinute).toFixed(2);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-80 flex flex-col items-center justify-center z-50">
+      <div className="bg-gray-900 p-4 rounded text-center space-y-2 w-80">
+        <div className="bg-gray-700 h-48 flex items-center justify-center rounded text-sm">Remote Video - {creatorName}</div>
+        <div className="bg-gray-700 h-24 flex items-center justify-center rounded text-sm">Your Video</div>
+        <div className="text-sm">Time: {seconds}s • Cost: ${cost}</div>
+        <button className="bg-red-600 w-full py-1 rounded" onClick={onEnd}>End Call</button>
+      </div>
+    </div>
+  );
+};
+
+export default CallSession;

--- a/src/components/GroupCard.tsx
+++ b/src/components/GroupCard.tsx
@@ -6,17 +6,17 @@ interface Group {
   members: number;
   thumbnail: string;
   live: boolean;
+  description: string;
 }
 
 const GroupCard: React.FC<{ group: Group }> = ({ group }) => (
   <a href={`/groups/${group.id}`} className="relative bg-gray-800 rounded-lg p-2 block hover:shadow-lg">
     <img src={group.thumbnail} alt={group.name} className="rounded" />
     {group.live && (
-      <div className="absolute top-2 left-2 bg-red-500 text-xs px-1 rounded">
-        Live
-      </div>
+      <div className="absolute top-2 left-2 bg-red-500 text-xs px-1 rounded">Live</div>
     )}
     <div className="mt-2 text-sm font-semibold">{group.name}</div>
+    <div className="text-xs text-gray-400">{group.description}</div>
     <div className="text-xs text-gray-400">{group.members} members</div>
     <button className="mt-2 w-full bg-pink-500 text-white py-1 rounded text-sm">Open</button>
   </a>

--- a/src/components/LiveStreamCard.tsx
+++ b/src/components/LiveStreamCard.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+interface LiveStreamCardProps {
+  avatarUrl: string;
+  username: string;
+  viewerCount: number;
+  isNew?: boolean;
+  isFeatured?: boolean;
+  streamPreviewUrl: string;
+}
+
+const LiveStreamCard: React.FC<LiveStreamCardProps> = ({
+  avatarUrl,
+  username,
+  viewerCount,
+  isNew,
+  isFeatured,
+  streamPreviewUrl,
+}) => {
+  const [showPreview, setShowPreview] = useState(false);
+
+  return (
+    <a
+      href={`/live/${username}`}
+      className="relative block bg-gray-800 rounded-lg overflow-hidden cursor-pointer hover:shadow-lg"
+      onMouseEnter={() => setShowPreview(true)}
+      onMouseLeave={() => setShowPreview(false)}
+      onFocus={() => setShowPreview(true)}
+      onBlur={() => setShowPreview(false)}
+    >
+      <img src={avatarUrl} alt={username} className="w-full h-40 object-cover" />
+      {showPreview && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-70">
+          <video
+            src={streamPreviewUrl}
+            autoPlay
+            loop
+            muted
+            className="w-full h-full object-cover"
+          />
+        </div>
+      )}
+      <div className="absolute top-2 left-2 bg-red-500 text-xs px-1 rounded">
+        {viewerCount} watching
+      </div>
+      {isFeatured && (
+        <div className="absolute top-2 right-2 bg-yellow-500 text-xs px-1 rounded">
+          Featured
+        </div>
+      )}
+      {isNew && !isFeatured && (
+        <div className="absolute top-2 right-2 bg-green-500 text-xs px-1 rounded">
+          New
+        </div>
+      )}
+      <div className="p-2 text-sm">@{username}</div>
+    </a>
+  );
+};
+
+export default LiveStreamCard;

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -38,7 +38,14 @@ const PostCard: React.FC<{ post: Post }> = ({ post }) => {
           Tip
         </button>
       </div>
-      <TipModal open={showTip} onClose={() => setShowTip(false)} />
+      <TipModal
+        isOpen={showTip}
+        onClose={() => setShowTip(false)}
+        onSubmit={(amt) => {
+          console.log('tip', amt);
+          setShowTip(false);
+        }}
+      />
     </div>
   );
 };

--- a/src/components/SubscriptionPost.tsx
+++ b/src/components/SubscriptionPost.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import TipModal from './TipModal';
+
+interface SubscriptionPostProps {
+  contentUrl: string;
+  isLocked: boolean;
+  price?: number;
+  isPPV?: boolean;
+  caption?: string;
+  timestamp: string;
+}
+
+const SubscriptionPost: React.FC<SubscriptionPostProps> = ({
+  contentUrl,
+  isLocked,
+  price = 0,
+  isPPV,
+  caption,
+  timestamp,
+}) => {
+  const [unlocked, setUnlocked] = useState(!isLocked);
+  const [showTip, setShowTip] = useState(false);
+
+  const unlock = () => {
+    setUnlocked(true);
+  };
+
+  return (
+    <div className="bg-gray-800 rounded-lg overflow-hidden relative">
+      <img
+        src={contentUrl}
+        alt="post"
+        className={`w-full ${unlocked ? '' : 'blur-md'}`}
+      />
+      {!unlocked && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-black bg-opacity-50 space-y-2">
+          <button
+            onClick={unlock}
+            className="bg-pink-500 text-white px-3 py-1 rounded"
+          >
+            {isPPV ? `Unlock for $${price}` : `Subscribe $${price}`}
+          </button>
+        </div>
+      )}
+      <div className="p-2 space-y-1 text-sm">
+        {caption && <div>{caption}</div>}
+        <div className="text-xs text-gray-400">{timestamp}</div>
+        <div className="flex space-x-4 pt-1">
+          <button className="hover:text-pink-400">Like</button>
+          <button className="hover:text-pink-400">Comment</button>
+          <button className="hover:text-pink-400" onClick={() => setShowTip(true)}>
+            Tip
+          </button>
+        </div>
+      </div>
+      <TipModal
+        isOpen={showTip}
+        onClose={() => setShowTip(false)}
+        onSubmit={(amt) => {
+          console.log('tip', amt);
+          setShowTip(false);
+        }}
+      />
+    </div>
+  );
+};
+
+export default SubscriptionPost;

--- a/src/components/TipModal.tsx
+++ b/src/components/TipModal.tsx
@@ -1,34 +1,76 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface TipModalProps {
-  open: boolean;
+  isOpen: boolean;
   onClose: () => void;
+  onSubmit: (tipAmount: number) => void;
 }
 
-const packs = [5, 10, 20, 50];
+const suggested = [5, 10, 20, 50];
 
-const TipModal: React.FC<TipModalProps> = ({ open, onClose }) => {
-  if (!open) return null;
+const TipModal: React.FC<TipModalProps> = ({ isOpen, onClose, onSubmit }) => {
+  const [amount, setAmount] = useState<number | ''>('');
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  useEffect(() => {
+    if (showConfirm) {
+      const t = setTimeout(() => {
+        setShowConfirm(false);
+        onClose();
+      }, 1500);
+      return () => clearTimeout(t);
+    }
+  }, [showConfirm, onClose]);
+
+  if (!isOpen) return null;
+
+  const sendTip = (value: number) => {
+    onSubmit(value);
+    setShowConfirm(true);
+  };
+
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50">
       <div className="bg-gray-900 p-4 rounded-lg w-72 text-center">
-        <h2 className="text-lg mb-2">Send Tip</h2>
-        <div className="space-y-2">
-          {packs.map((p) => (
+        {showConfirm ? (
+          <div className="text-lg text-green-400 animate-pulse">Thank you!</div>
+        ) : (
+          <>
+            <h2 className="text-lg mb-2">Send Tip</h2>
+            <div className="space-y-2">
+              {suggested.map((p) => (
+                <button
+                  key={p}
+                  className="w-full bg-pink-500 py-1 rounded text-white hover:bg-pink-600"
+                  onClick={() => sendTip(p)}
+                >
+                  {p} Coins
+                </button>
+              ))}
+            </div>
+            <div className="mt-2 flex items-center space-x-2">
+              <input
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(Number(e.target.value))}
+                className="flex-1 bg-gray-800 p-1 text-sm"
+                placeholder="Custom"
+              />
+              <button
+                className="bg-pink-500 px-3 py-1 rounded text-white"
+                onClick={() => typeof amount === 'number' && sendTip(amount)}
+              >
+                Send
+              </button>
+            </div>
             <button
-              key={p}
-              className="w-full bg-pink-500 py-1 rounded text-white hover:bg-pink-600"
+              className="mt-4 text-sm text-gray-400 hover:text-white"
+              onClick={onClose}
             >
-              {p} Coins
+              Close
             </button>
-          ))}
-        </div>
-        <button
-          className="mt-4 text-sm text-gray-400 hover:text-white"
-          onClick={onClose}
-        >
-          Close
-        </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import CallCard from '../components/CallCard';
-import CallInterface from '../components/CallInterface';
+import CallSession from '../components/CallSession';
 
 const mockCallCreators = [
   { id: 1, username: 'creator1', avatar: 'https://placekitten.com/220/200', rate: 2.5 },
@@ -21,9 +21,9 @@ const Calls: React.FC = () => {
         ))}
       </div>
       {active && (
-        <CallInterface
-          creator={active}
-          rate={active.rate}
+        <CallSession
+          creatorName={active.username}
+          ratePerMinute={active.rate}
           onEnd={() => setActive(null)}
         />
       )}

--- a/src/pages/Content.tsx
+++ b/src/pages/Content.tsx
@@ -1,19 +1,50 @@
 import React, { useState } from 'react';
-import PostCard from '../components/PostCard';
-import type { Post } from '../components/PostCard';
+import SubscriptionPost from '../components/SubscriptionPost';
 
-const mockPosts: Post[] = [
-  { id: 1, type: 'image', src: 'https://placekitten.com/400/300', locked: false },
-  { id: 2, type: 'video', src: 'https://www.w3schools.com/html/mov_bbb.mp4', locked: true, price: 5 },
-  { id: 3, type: 'image', src: 'https://placekitten.com/401/300', locked: true, price: 3 },
+const mockPosts = [
+  {
+    id: 1,
+    contentUrl: 'https://placekitten.com/400/300',
+    isLocked: false,
+    price: 0,
+    isPPV: false,
+    caption: 'Free cute cat',
+    timestamp: 'Just now',
+  },
+  {
+    id: 2,
+    contentUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+    isLocked: true,
+    price: 5,
+    isPPV: true,
+    caption: 'Exclusive video',
+    timestamp: '1h ago',
+  },
+  {
+    id: 3,
+    contentUrl: 'https://placekitten.com/401/300',
+    isLocked: true,
+    price: 10,
+    isPPV: false,
+    caption: 'Premium photo',
+    timestamp: '2h ago',
+  },
 ];
 
 const Content: React.FC = () => {
   const [posts] = useState(mockPosts);
   return (
     <div className="p-4 space-y-4 max-w-xl mx-auto">
-      {posts.map(p => (
-        <PostCard key={p.id} post={p} />
+      {posts.map((p) => (
+        <SubscriptionPost
+          key={p.id}
+          contentUrl={p.contentUrl}
+          isLocked={p.isLocked}
+          price={p.price}
+          isPPV={p.isPPV}
+          caption={p.caption}
+          timestamp={p.timestamp}
+        />
       ))}
     </div>
   );

--- a/src/pages/Creators.tsx
+++ b/src/pages/Creators.tsx
@@ -1,18 +1,50 @@
 import React, { useState } from 'react';
-import CreatorCard from '../components/CreatorCard';
+import LiveStreamCard from '../components/LiveStreamCard';
 
 const mockCreators = [
-  { id: 1, username: 'creator1', avatar: 'https://placekitten.com/210/200', online: true, rate: 2 },
-  { id: 2, username: 'creator2', avatar: 'https://placekitten.com/211/200', online: false, rate: 1.5 },
-  { id: 3, username: 'creator3', avatar: 'https://placekitten.com/212/200', online: true, rate: 3 },
+  {
+    id: 1,
+    username: 'creator1',
+    avatar: 'https://placekitten.com/210/200',
+    online: true,
+    rate: 2,
+    viewers: 120,
+    streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+  },
+  {
+    id: 2,
+    username: 'creator2',
+    avatar: 'https://placekitten.com/211/200',
+    online: false,
+    rate: 1.5,
+    viewers: 80,
+    streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+  },
+  {
+    id: 3,
+    username: 'creator3',
+    avatar: 'https://placekitten.com/212/200',
+    online: true,
+    rate: 3,
+    viewers: 200,
+    streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+  },
 ];
 
 const Creators: React.FC = () => {
   const [creators] = useState(mockCreators);
   return (
     <div className="p-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-      {creators.map(c => (
-        <CreatorCard key={c.id} creator={c} />
+      {creators.map((c) => (
+        <LiveStreamCard
+          key={c.id}
+          avatarUrl={c.avatar}
+          username={c.username}
+          viewerCount={c.viewers}
+          isNew={!c.online}
+          isFeatured={c.online}
+          streamPreviewUrl={c.streamPreviewUrl}
+        />
       ))}
     </div>
   );

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -1,10 +1,32 @@
 import React, { useState } from 'react';
-import StreamCard from '../components/StreamCard';
+import LiveStreamCard from '../components/LiveStreamCard';
 
 const mockStreams = [
-  { id: 1, username: 'creator1', viewers: 340, avatar: 'https://placekitten.com/200/200', featured: true },
-  { id: 2, username: 'creator2', viewers: 120, avatar: 'https://placekitten.com/201/200', featured: false, isNew: true },
-  { id: 3, username: 'creator3', viewers: 999, avatar: 'https://placekitten.com/202/200', featured: true },
+  {
+    id: 1,
+    username: 'creator1',
+    viewers: 340,
+    avatar: 'https://placekitten.com/200/200',
+    featured: true,
+    streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+  },
+  {
+    id: 2,
+    username: 'creator2',
+    viewers: 120,
+    avatar: 'https://placekitten.com/201/200',
+    featured: false,
+    isNew: true,
+    streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+  },
+  {
+    id: 3,
+    username: 'creator3',
+    viewers: 999,
+    avatar: 'https://placekitten.com/202/200',
+    featured: true,
+    streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+  },
 ];
 
 const Explore: React.FC = () => {
@@ -13,7 +35,15 @@ const Explore: React.FC = () => {
   return (
     <div className="p-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
       {streams.map((s) => (
-        <StreamCard key={s.id} stream={s} />
+        <LiveStreamCard
+          key={s.id}
+          avatarUrl={s.avatar}
+          username={s.username}
+          viewerCount={s.viewers}
+          isNew={s.isNew}
+          isFeatured={s.featured}
+          streamPreviewUrl={s.streamPreviewUrl}
+        />
       ))}
     </div>
   );

--- a/src/pages/Groups.tsx
+++ b/src/pages/Groups.tsx
@@ -2,8 +2,22 @@ import React, { useState } from 'react';
 import GroupCard from '../components/GroupCard';
 
 const mockGroups = [
-  { id: 1, name: 'Fans Club', members: 1200, thumbnail: 'https://placekitten.com/230/200', live: true },
-  { id: 2, name: 'VIP Room', members: 300, thumbnail: 'https://placekitten.com/231/200', live: false },
+  {
+    id: 1,
+    name: 'Fans Club',
+    members: 1200,
+    thumbnail: 'https://placekitten.com/230/200',
+    live: true,
+    description: 'Exclusive updates and streams',
+  },
+  {
+    id: 2,
+    name: 'VIP Room',
+    members: 300,
+    thumbnail: 'https://placekitten.com/231/200',
+    live: false,
+    description: 'Behind the scenes content',
+  },
 ];
 
 const Groups: React.FC = () => {

--- a/src/pages/groups/[id].tsx
+++ b/src/pages/groups/[id].tsx
@@ -3,6 +3,10 @@ import ChatBox from '../../components/ChatBox';
 import PostCard from '../../components/PostCard';
 import type { Post } from '../../components/PostCard';
 
+const pinned: Post[] = [
+  { id: 99, type: 'image', src: 'https://placekitten.com/425/300', locked: false },
+];
+
 const posts: Post[] = [
   { id: 1, type: 'image', src: 'https://placekitten.com/420/300', locked: false },
   { id: 2, type: 'image', src: 'https://placekitten.com/421/300', locked: false },
@@ -15,6 +19,12 @@ const GroupPage: React.FC = () => {
       <h1 className="text-xl font-semibold">Group {id}</h1>
       <div className="grid md:grid-cols-3 gap-4">
         <div className="md:col-span-2 space-y-4">
+          {pinned.map((p) => (
+            <div key={p.id}>
+              <div className="text-xs text-gray-400 mb-1">Pinned</div>
+              <PostCard post={p} />
+            </div>
+          ))}
           {posts.map((p) => (
             <PostCard key={p.id} post={p} />
           ))}

--- a/src/pages/live/[username].tsx
+++ b/src/pages/live/[username].tsx
@@ -26,7 +26,14 @@ const LivePage: React.FC = () => {
           </button>
         </div>
       </div>
-      <TipModal open={showTip} onClose={() => setShowTip(false)} />
+      <TipModal
+        isOpen={showTip}
+        onClose={() => setShowTip(false)}
+        onSubmit={(amt) => {
+          console.log('tip', amt);
+          setShowTip(false);
+        }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enable live streaming grid with new `LiveStreamCard`
- upgrade tipping modal and integrate in posts and live view
- add `SubscriptionPost` for paid content
- implement `CallSession` for video call UI
- enhance groups with descriptions and pinned posts

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688324b5a47083239012f74a0174f67b