### PR TITLE
Fix WebRTC dynamic WS URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository contains a prototype of the Feelynx platform. A simple WebRTC de
    ```bash
    PORT=3000 npm start
    ```
-   By default this launches a WebSocket server on `ws://localhost:8080`.
+   This launches a WebSocket server on the chosen port (e.g. `ws://localhost:8080`).
+   The WebRTC client automatically connects to the same host and port that served the page.
 4. Open `index.html` (or `webrtc.html`) in two separate browser windows. Navigate to the **Calls** tab and press **Start Call** in one of them to begin a peer‑to‑peer connection. Allow camera and microphone permissions when prompted.
 
 The demo uses a basic WebSocket signaling server and `RTCPeerConnection` with Google's public STUN server. The `Calls` tab on the main site now embeds the same WebRTC demo.

--- a/webrtc.js
+++ b/webrtc.js
@@ -11,7 +11,10 @@ const allowBtn = document.getElementById('allowPermissions');
 const denyBtn = document.getElementById('denyPermissions');
 const permissionModal = document.getElementById('permissionModal');
 
-const ws = new WebSocket('ws://localhost:8080');
+const wsProtocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+const wsPort = window.location.port ? `:${window.location.port}` : '';
+const wsUrl = `${wsProtocol}://${window.location.hostname}${wsPort}`;
+const ws = new WebSocket(wsUrl);
 let pc;
 let localStream;
 let muted = false;


### PR DESCRIPTION
## Summary
- compute WebSocket address from the page host/port in `webrtc.js`
- document auto-connect behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688329171f7c8323be069b35c44306cb