### PR TITLE
Add Node CI workflow with Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+Dockerfile
+.github
+.env

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,27 @@
+name: Node CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build --if-present
+      - run: docker build -t feelynx:${{ github.sha }} .
+      - name: Publish to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker tag feelynx:${{ github.sha }} ghcr.io/${{ github.repository }}/feelynx:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository }}/feelynx:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY . .
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -43,3 +43,21 @@ Run the server in production mode with:
 ```bash
 NODE_ENV=production npm start
 ```
+
+## CI and Docker Deployment
+
+The repository includes a GitHub Actions workflow defined in
+`.github/workflows/node.yml`. It installs dependencies, runs the test suite and
+builds a Docker image for the application. When changes are pushed to the
+`main` branch the workflow will also publish the image to GitHub Container
+Registry (GHCR) using the `GITHUB_TOKEN` provided by GitHub.
+
+### Triggering Production Deployments
+
+Merges or pushes to `main` automatically build and publish the Docker image. A
+deployment can also be initiated manually from the **Actions** tab by selecting
+the **Node CI** workflow and pressing **Run workflow**. Ensure your account has
+permissions to push packages so the image can be uploaded.
+
+If you would like to deploy to another container registry or hosting provider,
+edit the publish step in `node.yml` with your registry credentials.


### PR DESCRIPTION
## Summary
- build/test Node project using GitHub Actions
- build Docker images and publish to GHCR on pushes to `main`
- add minimal Dockerfile and ignore list
- document how deployments are triggered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883a83ba9d08323a2a34932898a3c65