### PR TITLE
Setup Vite with React typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "ws": "^8.18.3"
       },
       "devDependencies": {
-        "@types/react": "^18.2.37",
-        "@types/react-dom": "^18.2.15",
+        "@types/react": "^18.3.23",
+        "@types/react-dom": "^18.3.7",
         "autoprefixer": "^10.4.17",
         "lovable-tagger": "^1.1.7",
         "postcss": "^8.4.31",

--- a/package.json
+++ b/package.json
@@ -9,29 +9,30 @@
   "scripts": {
     "start": "node server.js",
     "test": "node test.js",
-    "build": "tsc"
+    "build": "tsc && vite build",
+    "dev": "vite"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^4.19.2",
-    "ws": "^8.18.3",
     "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.0.0",
     "helmet": "^7.0.0",
-    "express-rate-limit": "^7.0.0"
+    "ws": "^8.18.3",
+    "@types/react": "^18.3.23",
+    "@types/react-dom": "^18.3.7"
   },
   "devDependencies": {
-    "@types/react": "^18.2.37",
-    "@types/react-dom": "^18.2.15",
+    "autoprefixer": "^10.4.17",
     "lovable-tagger": "^1.1.7",
-    "vite": "^5.4.19",
+    "postcss": "^8.4.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5.3.3",
     "tailwindcss": "^3.4.1",
-    "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.17"
+    "typescript": "^5.3.3",
+    "vite": "^5.4.19"
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(
+  <React.StrictMode>
+    <div>Feelynx</div>
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "target": "es6",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "lib": ["DOM", "ES2021"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- install React type packages as runtime deps
- configure React JSX and DOM libs in `tsconfig.json`
- add Vite entry file `src/main.tsx`
- expose `dev` and updated `build` scripts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883a832a81083239665bd8e09d767ac