### PR TITLE
Add WebRTC hook and FastAPI signaling server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from routes import ws
+
+app = FastAPI()
+
+# Include WebSocket router
+app.include_router(ws.router)
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 regex==2024.11.6
+
+fastapi==0.110.0
+uvicorn==0.27.0.post1

--- a/routes/ws.py
+++ b/routes/ws.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+router = APIRouter()
+
+# Store active WebSocket connections
+connections = []
+
+@router.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    connections.append(ws)
+    try:
+        while True:
+            data = await ws.receive_text()
+            # Broadcast received data to all other connected clients
+            for conn in list(connections):
+                if conn is not ws:
+                    await conn.send_text(data)
+    except WebSocketDisconnect:
+        if ws in connections:
+            connections.remove(ws)

--- a/src/components/VideoChat.jsx
+++ b/src/components/VideoChat.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import useWebRTC from '../hooks/useWebRTC';
+
+export default function VideoChat({ clientId, targetId }) {
+  const { localVideoRef, remoteVideoRef, startCall, endCall } = useWebRTC(clientId, targetId);
+
+  return (
+    <div className="p-4 space-y-2">
+      <div className="flex space-x-2">
+        <video ref={localVideoRef} autoPlay muted className="w-48 bg-black rounded" />
+        <video ref={remoteVideoRef} autoPlay className="w-48 bg-black rounded" />
+      </div>
+      <div className="space-x-2">
+        <button onClick={startCall} className="px-2 py-1 bg-pink-600 text-white rounded">Start Call</button>
+        <button onClick={endCall} className="px-2 py-1 bg-gray-600 text-white rounded">End Call</button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useWebRTC.js
+++ b/src/hooks/useWebRTC.js
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+export default function useWebRTC(clientId, targetId) {
+  const localVideoRef = useRef(null);
+  const remoteVideoRef = useRef(null);
+  const wsRef = useRef(null);
+  const pcRef = useRef(null);
+  const streamRef = useRef(null);
+
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const port = window.location.port ? `:${window.location.port}` : '';
+    wsRef.current = new WebSocket(`${protocol}://${window.location.hostname}${port}/ws`);
+
+    wsRef.current.onmessage = async (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.to && msg.to !== clientId) return;
+      await ensurePeer();
+      if (msg.offer) {
+        await pcRef.current.setRemoteDescription(msg.offer);
+        const answer = await pcRef.current.createAnswer();
+        await pcRef.current.setLocalDescription(answer);
+        wsRef.current.send(JSON.stringify({ from: clientId, to: msg.from, answer }));
+      } else if (msg.answer) {
+        await pcRef.current.setRemoteDescription(msg.answer);
+      } else if (msg.candidate) {
+        try {
+          await pcRef.current.addIceCandidate(msg.candidate);
+        } catch {}
+      }
+    };
+
+    return () => {
+      wsRef.current?.close();
+      pcRef.current?.close();
+      streamRef.current?.getTracks().forEach(t => t.stop());
+    };
+  }, [clientId]);
+
+  const ensurePeer = async () => {
+    if (pcRef.current) return;
+    pcRef.current = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+    pcRef.current.onicecandidate = ({ candidate }) => {
+      if (candidate) wsRef.current?.send(JSON.stringify({ from: clientId, to: targetId, candidate }));
+    };
+    pcRef.current.ontrack = (e) => {
+      remoteVideoRef.current.srcObject = e.streams[0];
+    };
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(t => pcRef.current.addTrack(t, streamRef.current));
+    }
+  };
+
+  const startCall = useCallback(async () => {
+    streamRef.current = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    localVideoRef.current.srcObject = streamRef.current;
+    await ensurePeer();
+    streamRef.current.getTracks().forEach(t => pcRef.current.addTrack(t, streamRef.current));
+    const offer = await pcRef.current.createOffer();
+    await pcRef.current.setLocalDescription(offer);
+    wsRef.current.send(JSON.stringify({ from: clientId, to: targetId, offer }));
+  }, [clientId, targetId]);
+
+  const endCall = useCallback(() => {
+    pcRef.current?.close();
+    pcRef.current = null;
+    streamRef.current?.getTracks().forEach(t => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  return { localVideoRef, remoteVideoRef, startCall, endCall };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import VideoChat from './components/VideoChat';
 
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(
   <React.StrictMode>
-    <div>Feelynx</div>
+    <VideoChat clientId="user1" targetId="user2" />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- implement FastAPI server with WebSocket broadcast
- expose `/ws` endpoint via router
- extend requirements
- add WebRTC React hook and `VideoChat` component
- embed `VideoChat` demo in `main.tsx`

## Testing
- `npm test`
- `npm run build` *(fails: JSX type errors)*
- `pip install -r requirements.txt`
- `python -m py_compile main.py routes/ws.py`
- `python -m uvicorn main:app --port 8000 --reload` *(manual run)*

------
https://chatgpt.com/codex/tasks/task_e_6883e582a0608323a95b45eca7a6399c