### PR TITLE
Add Explorers API and React page

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,8 @@ Generate production assets with:
 ```bash
 npm run build
 ```
+
+## Explorers Feature
+The new Explorers page consumes `/api/creators` to display creators with
+search, filtering and sorting. See [docs/explorers-api.md](docs/explorers-api.md)
+for details on extending the API and integrating real-time status updates.

--- a/docs/explorers-api.md
+++ b/docs/explorers-api.md
@@ -1,0 +1,48 @@
+# Explorers API and Integration
+
+This document outlines the demo "Explorers" feature which exposes a simple
+creator discovery API and a matching React page.
+
+## REST Endpoints
+
+### `GET /api/creators`
+Returns a JSON array of creators.
+Query parameters:
+
+- `country` – filter by ISO country code
+- `specialty` – filter by creator specialty
+- `isLive` – pass `true` to only return live creators
+- `search` – case-insensitive match on username or display name
+- `sort` – `trendingScore`, `createdAt`, or `followers`
+
+### `POST /api/creators`
+Adds a demo creator to the in-memory list. This is for testing only.
+
+```
+POST /api/creators
+{ "username": "test", "displayName": "Test" }
+```
+
+## Database Model
+
+A Prisma model is provided in `prisma/schema.prisma` which can be used with a
+PostgreSQL database. Swap the provider to `mongodb` if a MongoDB deployment is
+preferred.
+
+## Real-Time Updates
+
+The WebSocket server sends a welcome message on connection. It can be extended to
+broadcast creator status changes:
+
+```javascript
+wss.clients.forEach(c => c.send(JSON.stringify({ type: 'status', id, live: true })))
+```
+
+## Extension Points
+
+- **Payments** – integrate a payment provider to process tips and subscriptions.
+- **Messaging** – add authenticated routes and database tables for private chats.
+- **Group Rooms** – expand the WebSocket/LiveKit logic to manage multiple chat rooms.
+
+Security, authentication and data validation should be carefully reviewed before
+any production deployment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-rate-limit": "^7.0.0",
@@ -1395,6 +1396,19 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2458,7 +2472,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react-dom": "^18.3.7",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "cors": "^2.8.5",
     "express-rate-limit": "^7.0.0",
     "helmet": "^7.0.0",
     "livekit-client": "^2.15.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,22 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Creator {
+  id            Int      @id @default(autoincrement())
+  username      String   @unique
+  displayName   String
+  avatar        String
+  country       String
+  specialty     String
+  isLive        Boolean
+  followers     Int
+  trendingScore Float
+  createdAt     DateTime @default(now())
+  lastOnline    DateTime
+}

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const WebSocket = require('ws');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const { AccessToken } = require('livekit-server-sdk');
+const cors = require('cors');
 
 const livekitHost = process.env.LIVEKIT_HOST || 'http://localhost:7880';
 const livekitApiKey = process.env.LIVEKIT_API_KEY || '';
@@ -13,12 +14,107 @@ const livekitApiSecret = process.env.LIVEKIT_API_SECRET || '';
 const port = process.env.PORT || 8080;
 const app = express();
 app.use(helmet());
+app.use(cors());
+app.use(express.json());
+
+// Mock list of creators. Replace with a database in production.
+let creators = [
+  {
+    id: 1,
+    username: 'alpha',
+    displayName: 'Alpha One',
+    avatar: 'https://placekitten.com/200/200',
+    country: 'US',
+    specialty: 'gaming',
+    isLive: true,
+    followers: 1000,
+    trendingScore: 50,
+    createdAt: new Date().toISOString(),
+    lastOnline: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    username: 'beta',
+    displayName: 'Beta Two',
+    avatar: 'https://placekitten.com/201/200',
+    country: 'CA',
+    specialty: 'music',
+    isLive: false,
+    followers: 500,
+    trendingScore: 20,
+    createdAt: new Date(Date.now() - 86400000).toISOString(),
+    lastOnline: new Date(Date.now() - 3600000).toISOString(),
+  },
+];
 
 const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
 app.use(limiter);
 
 app.get('/health', (req, res) => {
   res.send('ok');
+});
+
+/**
+ * GET /api/creators
+ * Returns list of creators with optional filtering and sorting.
+ */
+app.get('/api/creators', (req, res) => {
+  let result = [...creators];
+  const { country, specialty, isLive, search, sort } = req.query;
+
+  if (country) {
+    result = result.filter(c => c.country === country);
+  }
+  if (specialty) {
+    result = result.filter(c => c.specialty === specialty);
+  }
+  if (typeof isLive !== 'undefined') {
+    const live = isLive === 'true';
+    result = result.filter(c => c.isLive === live);
+  }
+  if (search) {
+    const q = search.toString().toLowerCase();
+    result = result.filter(
+      c =>
+        c.username.toLowerCase().includes(q) ||
+        c.displayName.toLowerCase().includes(q)
+    );
+  }
+  if (sort) {
+    if (sort === 'trendingScore') {
+      result.sort((a, b) => b.trendingScore - a.trendingScore);
+    } else if (sort === 'createdAt') {
+      result.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    } else if (sort === 'followers') {
+      result.sort((a, b) => b.followers - a.followers);
+    }
+  }
+
+  res.json(result);
+});
+
+/**
+ * POST /api/creators
+ * Adds a demo creator to the in-memory list.
+ */
+app.post('/api/creators', (req, res) => {
+  const data = req.body || {};
+  const id = creators.length ? creators[creators.length - 1].id + 1 : 1;
+  const newCreator = {
+    id,
+    username: data.username || `user${id}`,
+    displayName: data.displayName || `User ${id}`,
+    avatar: data.avatar || 'https://placekitten.com/200/200',
+    country: data.country || 'US',
+    specialty: data.specialty || 'general',
+    isLive: Boolean(data.isLive),
+    followers: data.followers || 0,
+    trendingScore: data.trendingScore || 0,
+    createdAt: data.createdAt || new Date().toISOString(),
+    lastOnline: data.lastOnline || new Date().toISOString(),
+  };
+  creators.push(newCreator);
+  res.status(201).json(newCreator);
 });
 
 // Serve static files from the project root so index.html works out of the box
@@ -50,6 +146,12 @@ wss.on('connection', ws => {
       }
     });
   });
+  // Example: notify clients about status changes
+  ws.send(JSON.stringify({ type: 'welcome', connectedClients: wss.clients.size }));
 });
 
 console.log(`WebSocket signaling server running on ws://localhost:${port}`);
+
+// In a real deployment review authentication, rate limiting and database
+// operations closely. Payments, messaging and group room functionality would
+// extend these endpoints with proper access controls.

--- a/src/pages/Explorers.tsx
+++ b/src/pages/Explorers.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from 'react';
+
+interface Creator {
+  id: number;
+  username: string;
+  displayName: string;
+  avatar: string;
+  country: string;
+  specialty: string;
+  isLive: boolean;
+}
+
+// Fetch creators from the backend with optional query parameters
+const Explorers: React.FC = () => {
+  const [creators, setCreators] = useState<Creator[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const [country, setCountry] = useState('');
+  const [specialty, setSpecialty] = useState('');
+  const [liveOnly, setLiveOnly] = useState(false);
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<'trendingScore' | 'createdAt' | 'followers'>('trendingScore');
+
+  // Build query string and fetch creators
+  const fetchCreators = () => {
+    setLoading(true);
+    setError('');
+    const params = new URLSearchParams();
+    if (country) params.append('country', country);
+    if (specialty) params.append('specialty', specialty);
+    if (liveOnly) params.append('isLive', 'true');
+    if (search) params.append('search', search);
+    params.append('sort', sort);
+
+    fetch(`/api/creators?${params.toString()}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('failed');
+        return res.json();
+      })
+      .then((data) => setCreators(data))
+      .catch(() => setError('Failed to load creators'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchCreators();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [country, specialty, liveOnly, search, sort]);
+
+  return (
+    <div className="p-4" aria-live="polite">
+      <div className="flex flex-wrap gap-2 mb-4 items-center">
+        <input
+          className="border p-1 rounded text-sm"
+          placeholder="Search creators"
+          aria-label="Search creators"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className="border p-1 rounded text-sm"
+          aria-label="Filter by country"
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+        >
+          <option value="">All Countries</option>
+          <option value="US">US</option>
+          <option value="CA">CA</option>
+        </select>
+        <select
+          className="border p-1 rounded text-sm"
+          aria-label="Filter by specialty"
+          value={specialty}
+          onChange={(e) => setSpecialty(e.target.value)}
+        >
+          <option value="">All Specialties</option>
+          <option value="gaming">Gaming</option>
+          <option value="music">Music</option>
+        </select>
+        <label className="flex items-center text-sm space-x-1">
+          <input
+            type="checkbox"
+            checked={liveOnly}
+            onChange={(e) => setLiveOnly(e.target.checked)}
+            aria-label="Live now"
+          />
+          <span>Live now</span>
+        </label>
+        <div className="flex space-x-1 ml-auto">
+          <button
+            className={`px-2 py-1 rounded text-sm ${sort === 'trendingScore' ? 'bg-pink-500 text-white' : 'border'}`}
+            onClick={() => setSort('trendingScore')}
+          >
+            Trending
+          </button>
+          <button
+            className={`px-2 py-1 rounded text-sm ${sort === 'createdAt' ? 'bg-pink-500 text-white' : 'border'}`}
+            onClick={() => setSort('createdAt')}
+          >
+            New
+          </button>
+          <button
+            className={`px-2 py-1 rounded text-sm ${sort === 'followers' ? 'bg-pink-500 text-white' : 'border'}`}
+            onClick={() => setSort('followers')}
+          >
+            Most Followers
+          </button>
+        </div>
+      </div>
+
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {creators.map((c) => (
+          <div key={c.id} className="border rounded p-2 text-center bg-gray-800 text-white">
+            <img
+              src={c.avatar}
+              alt={c.displayName}
+              className="w-full h-32 object-cover rounded"
+            />
+            <div className="mt-2 font-semibold">{c.displayName}</div>
+            <div className="text-xs text-gray-400">@{c.username}</div>
+            <div className="text-xs">
+              {c.country} · {c.specialty}
+            </div>
+            {c.isLive && (
+              <span className="inline-block mt-1 px-2 bg-green-500 text-xs rounded" aria-label="Live badge">
+                Live
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Explorers;


### PR DESCRIPTION
## Summary
- add `/api/creators` API with filtering, sorting and POST to add demo data
- enable CORS and JSON body parsing
- scaffold Prisma `Creator` model
- create Explorers React page that fetches the API with filters
- document the Explorers feature and extension points

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a81019758832398924eb2450c8452