### PR TITLE
Add peer connection guide button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a prototype of the Feelynx platform. A simple WebRTC demonstration is included for testing audio/video calls.
 
+If you cannot access the official WebRTC guides, see [`docs/peer-connections-overview.md`](docs/peer-connections-overview.md) for a short walkthrough of creating a peer connection. The **Calls** tab now includes a "Peer Connection Guide" button linking to this document.
+
 ## Running the demo
 1. Copy `.env.example` to `.env` and fill in your Firebase credentials.
 2. Install dependencies:

--- a/docs/peer-connections-overview.md
+++ b/docs/peer-connections-overview.md
@@ -1,0 +1,64 @@
+# WebRTC Peer Connection Overview
+
+This document summarizes the key steps for establishing a basic peer-to-peer connection using WebRTC. It is an alternative to the "Peer Connections" guide from `webrtc.org` which may be inaccessible in some environments.
+
+## 1. Gather local media
+Use `navigator.mediaDevices.getUserMedia()` to request access to the user's camera and microphone. Attach the resulting stream to a local `<video>` element so the user can see their own feed.
+
+```javascript
+const localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+localVideo.srcObject = localStream;
+```
+
+## 2. Create an `RTCPeerConnection`
+Instantiate a new `RTCPeerConnection`, optionally providing STUN/TURN servers for NAT traversal. Add the tracks from the local stream to the connection.
+
+```javascript
+const pc = new RTCPeerConnection({
+  iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+});
+localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
+```
+
+## 3. Exchange offers and answers
+Use a signaling mechanism (e.g. WebSocket) to exchange SDP offers and answers between peers.
+
+```javascript
+const offer = await pc.createOffer();
+await pc.setLocalDescription(offer);
+// send offer to the remote peer
+```
+
+When an offer is received, set it as the remote description, create an answer, and send it back.
+
+```javascript
+await pc.setRemoteDescription(remoteOffer);
+const answer = await pc.createAnswer();
+await pc.setLocalDescription(answer);
+// send answer to the caller
+```
+
+## 4. Handle ICE candidates
+As ICE candidates become available, share them with the remote peer and add the received candidates to the connection.
+
+```javascript
+pc.onicecandidate = event => {
+  if (event.candidate) {
+    // send candidate to remote peer
+  }
+};
+
+// when receiving a candidate from remote
+await pc.addIceCandidate(remoteCandidate);
+```
+
+## 5. Display the remote stream
+When tracks from the remote peer are added to the connection, attach them to a `<video>` element so users can see and hear each other.
+
+```javascript
+pc.ontrack = event => {
+  remoteVideo.srcObject = event.streams[0];
+};
+```
+
+These steps form the core of setting up a WebRTC peer connection. The accompanying `webrtc.js` file in this repository provides a working example using a simple WebSocket signaling server.

--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@
 
                     <div class="webrtc-demo">
                         <button id="startCall" data-i18n="calls.start">Start Call</button>
+                        <a href="docs/peer-connections-overview.md" class="btn btn--outline btn--sm" id="peerGuideBtn" target="_blank">Peer Connection Guide</a>
                         <div id="videos">
                             <video id="localVideo" autoplay muted></video>
                             <video id="remoteVideo" autoplay></video>

--- a/webrtc.html
+++ b/webrtc.html
@@ -26,6 +26,7 @@
       <button id="startCall" class="px-4 py-2 bg-pink-600 rounded text-white hover:bg-pink-500">Start Call</button>
       <button id="muteButton" class="px-4 py-2 bg-purple-600 rounded text-white hidden" title="Mute/unmute audio">Mute</button>
       <button id="endCall" class="px-4 py-2 bg-gray-700 rounded text-white hidden" title="End call">End</button>
+      <a href="docs/peer-connections-overview.md" target="_blank" class="px-4 py-2 bg-gray-800 rounded text-white">Peer Connection Guide</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- link offline doc from Calls tab and WebRTC demo
- mention new button in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883e103b0008323bc65f10a2fa1ccd1