### PR TITLE
Serve static public assets

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,11 @@ const app = express();
 app.use(helmet());
 app.use(cors());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
 
 // Mock list of creators. Replace with a database in production.
 let creators = [


### PR DESCRIPTION
## Summary
- Serve static files from the `public` directory
- Handle root path by sending `public/index.html`

## Testing
- `npm test` *(fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh/...)*

------
https://chatgpt.com/codex/tasks/task_e_688afbe6704c8323953866bdc01e24ea