### PR TITLE
feat: improve WebSocket connection handling

### DIFF
--- a/src/hooks/useWebRTC.d.ts
+++ b/src/hooks/useWebRTC.d.ts
@@ -5,4 +5,5 @@ export default function useWebRTC(clientId: string, targetId: string): {
   endCall: () => void;
   mediaError: string;
   isConnecting: boolean;
+  connectionError: string;
 };


### PR DESCRIPTION
## Summary
- default WebSocket hostname and port with env and location fallbacks
- expose `connectionError` and handle WebSocket connection failures

## Testing
- `npm test` *(fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688aff24897c832384eb9642550951b0