### PR TITLE
Remove duplicate JSON body parser middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,6 @@ app.use(express.json());
 
 const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
 app.use(limiter);
-app.use(express.json());
 
 const upload = multer({ storage: multer.memoryStorage() });
 


### PR DESCRIPTION
## Summary
- remove redundant `express.json()` middleware

## Testing
- `npm test` *(fails: Invalid package.json JSON.parse error)*
- `node test.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_688d76e984148323bb9b54a2b59de648