### PR TITLE
feat: enforce JWT secret configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,6 +6,12 @@ const WebSocket = require('ws');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 
+const jwtSecret = process.env.JWT_SECRET;
+if (!jwtSecret) {
+  console.error('JWT_SECRET environment variable is required');
+  process.exit(1);
+}
+
 const port = process.env.PORT || 8080;
 const app = express();
 app.use(helmet());
@@ -80,7 +86,7 @@ function requireAdmin(req, res, next) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
   try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const payload = jwt.verify(token, jwtSecret);
     if (payload.role !== 'admin') {
       return res.status(403).json({ error: 'Forbidden' });
     }


### PR DESCRIPTION
## Summary
- exit at startup when `JWT_SECRET` is not provided
- use validated secret for JWT verification in admin auth

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d76ebe2808323a2208a13b15d31bf