### PR TITLE
Include targetId in WebRTC hook effect dependencies

### DIFF
--- a/src/hooks/useWebRTC.js
+++ b/src/hooks/useWebRTC.js
@@ -51,7 +51,7 @@ export default function useWebRTC(clientId, targetId) {
       pcRef.current?.close();
       streamRef.current?.getTracks().forEach(t => t.stop());
     };
-  }, [clientId]);
+  }, [clientId, targetId]);
 
   const ensurePeer = async () => {
     if (pcRef.current) return;


### PR DESCRIPTION
## Summary
- include `targetId` in WebRTC hook effect dependencies so connection resets on target changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e1fc0d7988323940128e1b8217781