### PR TITLE
Handle invalid JSON in WebRTC messages

### DIFF
--- a/src/hooks/useWebRTC.js
+++ b/src/hooks/useWebRTC.js
@@ -29,7 +29,13 @@ export default function useWebRTC(clientId, targetId) {
     };
 
     wsRef.current.onmessage = async (event) => {
-      const msg = JSON.parse(event.data);
+      let msg;
+      try {
+        msg = JSON.parse(event.data);
+      } catch (err) {
+        console.error('Failed to parse WebSocket message', err);
+        return;
+      }
       if (msg.to && msg.to !== clientId) return;
       await ensurePeer();
       if (msg.offer) {


### PR DESCRIPTION
## Summary
- gracefully ignore malformed WebSocket messages in useWebRTC hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e1fc601d08323907fa971c59cee37