### PR TITLE
feat: sanitize S3 folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ available at `/health`.
 | `LIVEKIT_API_SECRET` | API secret for LiveKit. |
 | `FIREBASE_*` | Firebase configuration keys. |
 
+### S3 Upload Folders
+
+When using the `uploadToS3` helper, the `folder` argument must contain only
+letters, numbers, hyphens, underscores or forward slashes. Leading or trailing
+slashes and path traversal segments such as `..` are rejected.
+
 Run the server in production mode with:
 
 ```bash


### PR DESCRIPTION
## Summary
- sanitize S3 upload folder names to avoid traversal and illegal characters
- document allowed S3 folder format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e1fcc9798832387718589701fb8a8