### PR TITLE
Add LiveKit placeholders to environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ MEDIA_BASE_URL=https://cdn.example.com/
 
 # LiveKit
 
+LIVEKIT_HOST=wss://your-livekit-host
+LIVEKIT_API_KEY=your-api-key
+LIVEKIT_API_SECRET=your-api-secret
+


### PR DESCRIPTION
## Summary
- include LiveKit host and API credentials placeholders in `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68900771f2b08323a375d981aab67b83