### PR TITLE
Serve public index at root path

### DIFF
--- a/server.js
+++ b/server.js
@@ -144,6 +144,11 @@ function requireAdmin(req, res, next) {
   }
 }
 
+app.use(express.static(path.join(__dirname, 'public')));
+app.get('/', (_, res) =>
+  res.sendFile(path.join(__dirname, 'public', 'index.html'))
+);
+
 app.get('/health', (req, res) => {
   res.send('ok');
 });


### PR DESCRIPTION
## Summary
- serve static assets from public directory and load public/index.html at root

## Testing
- `npm test`
- `curl -I http://localhost:8080/`


------
https://chatgpt.com/codex/tasks/task_e_68916d056b04832397f3f827798e2b5f