### PR TITLE
Serve frontend via FastAPI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,23 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+import pathlib
 from routes import ws
 
 app = FastAPI()
 
 # Include WebSocket router
 app.include_router(ws.router)
+
+# Determine the path to the front-end build
+FRONTEND_DIR = pathlib.Path(__file__).resolve().parent / "public"
+
+# Serve static assets
+app.mount("/assets", StaticFiles(directory=FRONTEND_DIR), name="assets")
+
+@app.get("/")
+async def serve_index():
+    return FileResponse(FRONTEND_DIR / "index.html")
 
 @app.get("/health")
 def health_check():

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from main import app
+
+client = TestClient(app)
+
+def test_root_serves_index_html():
+    response = client.get("/")
+    assert response.status_code == 200
+    index_path = Path(__file__).resolve().parent.parent / "public" / "index.html"
+    assert response.text == index_path.read_text()
+
+def test_static_asset_served():
+    response = client.get("/assets/style.css")
+    assert response.status_code == 200
+    asset_path = Path(__file__).resolve().parent.parent / "public" / "style.css"
+    assert response.text == asset_path.read_text()


### PR DESCRIPTION
## Summary
- serve built frontend from `public/` directory using FastAPI's static files
- expose root endpoint returning `index.html` and mount `/assets`
- add tests verifying index and asset serving

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68916d06d3f4832397c558d579231369