### PR TITLE
chore: set expo start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "start": "node server.js",
+    "start": "expo start",
     "test": "node test.js",
     "build": "tsc && vite build",
     "dev": "vite"


### PR DESCRIPTION
## Summary
- use `expo start` for project start script

## Testing
- `npm install --legacy-peer-deps`
- `npm test`
- `npx expo start --non-interactive` *(fails: npm warnings, missing Expo configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689174a272a48323abd09f3f9c558133