### PR TITLE
feat: centralize LiveKit room handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,10 @@ S3_BUCKET=your-bucket
 MEDIA_BASE_URL=https://cdn.example.com/
 
 # LiveKit
-LIVEKIT_HOST=https://your-livekit-host
+LIVEKIT_HOST=wss://your-livekit-host
 LIVEKIT_API_KEY=your-livekit-api-key
 LIVEKIT_API_SECRET=your-livekit-api-secret
 
-LIVEKIT_HOST=wss://your-livekit-host
-LIVEKIT_API_KEY=your-api-key
-LIVEKIT_API_SECRET=your-api-secret
+# Frontend origin for CORS (optional, comma separated for multiple)
+CLIENT_ORIGIN=http://localhost:3000
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,21 @@ For a more fully featured experience you can run the project against [LiveKit](h
 
 ### Room Management
 
-With your LiveKit credentials configured, the server exposes a few helper
-endpoints for room management:
+With your LiveKit credentials configured, the server exposes helper endpoints
+that the web and mobile apps can use to manage streaming rooms:
 
-- `POST /livekit-room` – create a room. Pass JSON such as
-  `{ "name": "myroom", "emptyTimeout": 600, "maxParticipants": 20 }`.
-- `GET /livekit-room` – list all active rooms.
-- `DELETE /livekit-room/:name` – delete a room by name.
+- `POST /livekit/create-room` – create a new room. Send JSON
+  `{ "name": "myroom" }`.
+- `POST /livekit/join-room` – ensure a room exists and receive a LiveKit token
+  for the authenticated user. Body example:
+  `{ "room": "myroom", "role": "creator" }`.
+- `POST /livekit/token` – generate a token without modifying the room. Body is
+  `{ "room": "myroom", "role": "fan" }`.
 
-These endpoints require `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET` to be set and
-proxy directly to the LiveKit `RoomService` API.
+All requests require a valid JWT in the `Authorization: Bearer <token>` header.
+The generated LiveKit token inherits the user's identity and expires after one
+hour. Set `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET` in your environment for
+these endpoints to work.
 
 ## Lovense Integration
 
@@ -91,6 +96,7 @@ available at `/health`.
 | `LIVEKIT_HOST` | LiveKit server URL. |
 | `LIVEKIT_API_KEY` | API key for LiveKit. |
 | `LIVEKIT_API_SECRET` | API secret for LiveKit. |
+| `CLIENT_ORIGIN` | Allowed frontend origin(s) for CORS. |
 | `FIREBASE_*` | Firebase configuration keys. |
 
 ### S3 Upload Folders


### PR DESCRIPTION
## Summary
- add JWT auth middleware and CORS configuration for web/mobile clients
- expose `/livekit/token`, `/livekit/create-room` and `/livekit/join-room` endpoints that issue role-based LiveKit tokens
- document new LiveKit workflow and environment variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689175e48d248323a8368c6350f991d0