### PR TITLE
fix: use functional state updates to avoid stale closures

### DIFF
--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -12,7 +12,10 @@ const ChatBox: React.FC = () => {
 
   const send = () => {
     if (!value) return;
-    setMessages([...messages, { id: messages.length + 1, author: 'me', text: value }]);
+    setMessages((prev) => [
+      ...prev,
+      { id: prev.length + 1, author: 'me', text: value },
+    ]);
     setValue('');
   };
 

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -41,7 +41,7 @@ const Admin: React.FC = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id }),
     });
-    setPendingCreators(pendingCreators.filter((c) => c.id !== id));
+    setPendingCreators((prev) => prev.filter((c) => c.id !== id));
   };
 
   const banUser = async (id: number) => {
@@ -58,7 +58,7 @@ const Admin: React.FC = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id }),
     });
-    setReports(reports.filter((r) => r.id !== id));
+    setReports((prev) => prev.filter((r) => r.id !== id));
   };
 
   return (


### PR DESCRIPTION
## Summary
- avoid stale closures when approving creators and reviewing reports by using functional state updates
- append new chat messages with a functional update to rely on latest state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689183a4b068832394f94ff922aab7d3