### PR TITLE
Handle missing or corrupt DB

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,8 +41,17 @@ app.use(
 const DB_PATH = path.join(__dirname, 'db.json');
 
 async function readDB() {
-  const data = await fs.promises.readFile(DB_PATH, 'utf8');
-  return JSON.parse(data);
+  try {
+    const data = await fs.promises.readFile(DB_PATH, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    if (err.code === 'ENOENT' || err instanceof SyntaxError) {
+      const defaultData = { users: [], purchases: [] };
+      await writeDB(defaultData);
+      return defaultData;
+    }
+    throw err;
+  }
 }
 
 async function writeDB(data) {


### PR DESCRIPTION
## Summary
- guard `readDB` against missing or malformed `db.json`
- seed a default `{users: [], purchases: []}` DB when problems occur

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891838da28c8323a5ae93860fc4b80f