### PR TITLE
Fix static serving directory to resolve 404

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,7 @@
 :80 {
-    root * dist
+    # Serve built assets from the public directory to avoid 404s when
+    # no Vite build output (dist) is present.
+    root * public
     file_server
     try_files {path} /index.html
 }


### PR DESCRIPTION
## Summary
- Serve static assets from the `public` directory in the Caddy configuration so the site loads even when no `dist` build exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918c5e73dc83239cf0fef8cd7323c2