### PR TITLE
fix: serve frontend from dist directory

### DIFF
--- a/server.js
+++ b/server.js
@@ -204,7 +204,7 @@ function authenticate(req, res, next) {
   }
 }
 
-const frontendDir = path.join(__dirname, 'public');
+const frontendDir = path.join(__dirname, 'dist');
 // Serve the compiled frontend assets.
 app.use(express.static(frontendDir));
 


### PR DESCRIPTION
## Summary
- serve compiled frontend from the `dist` directory
- keep wildcard route serving the SPA entry point

## Testing
- `npm run build`
- `npm test`
- `curl -s http://localhost:8080 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892001456b883238d8bffac3e762d4a