### PR TITLE
feat: serve public assets when dist missing

### DIFF
--- a/server.js
+++ b/server.js
@@ -204,8 +204,16 @@ function authenticate(req, res, next) {
   }
 }
 
-const frontendDir = path.join(__dirname, 'dist');
-// Serve the compiled frontend assets.
+// Determine the frontend directory. Prefer the built assets in "dist" if they
+// exist; otherwise fall back to the raw files in "public" so the server can
+// still serve something meaningful in development or when a build hasn't run
+// yet. This prevents 404 errors on the root path when the dist folder is
+// missing.
+const distDir = path.join(__dirname, 'dist');
+const publicDir = path.join(__dirname, 'public');
+const frontendDir = fs.existsSync(distDir) ? distDir : publicDir;
+
+// Serve the frontend assets from the chosen directory.
 app.use(express.static(frontendDir));
 
 // Dedicated health-check endpoint so "/" always serves the app.


### PR DESCRIPTION
## Summary
- fall back to serving `public` files when `dist` build output is absent to avoid 404s

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689207088bc88323bde21b52c188b13d