### PR TITLE
Support GET for LiveKit endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ For a more fully featured experience you can run the project against [LiveKit](h
 With your LiveKit credentials configured, the server exposes helper endpoints
 that the web and mobile apps can use to manage streaming rooms:
 
-- `POST /livekit/create-room` – create a new room. Send JSON
-  `{ "name": "myroom" }`.
-- `POST /livekit/join-room` – ensure a room exists and receive a LiveKit token
-  for the authenticated user. Body example:
+- `GET` or `POST` `/livekit/create-room` – create a new room. Provide
+  `{ "name": "myroom" }` as JSON or query parameters.
+- `GET` or `POST` `/livekit/join-room` – ensure a room exists and receive a
+  LiveKit token for the authenticated user. Example payload:
   `{ "room": "myroom", "role": "creator" }`.
-- `POST /livekit/token` – generate a token without modifying the room. Body is
-  `{ "room": "myroom", "role": "fan" }`.
+- `GET` or `POST` `/livekit/token` – generate a token without modifying the
+  room. Supply `{ "room": "myroom", "role": "fan" }` via JSON or query
+  parameters.
 
 All requests require a valid JWT in the `Authorization: Bearer <token>` header.
 The generated LiveKit token inherits the user's identity and expires after one

--- a/server.js
+++ b/server.js
@@ -222,9 +222,9 @@ app.get('/health', (_req, res) => {
 });
 
 // Generate a LiveKit access token for the authenticated user.
-// POST /livekit/token { room: string, role: 'creator' | 'fan' }
-app.post('/livekit/token', ensureLiveKitEnv, authenticate, (req, res) => {
-  const { room, role } = req.body;
+// POST or GET /livekit/token { room: string, role: 'creator' | 'fan' }
+function handleLivekitToken(req, res) {
+  const { room, role } = req.method === 'POST' ? req.body : req.query;
   if (!room || !role) {
     return res.status(400).json({ error: 'room and role are required' });
   }
@@ -241,13 +241,15 @@ app.post('/livekit/token', ensureLiveKitEnv, authenticate, (req, res) => {
     canSubscribe: true,
   });
   res.json({ token: at.toJwt() });
-});
+}
+app.post('/livekit/token', ensureLiveKitEnv, authenticate, handleLivekitToken);
+app.get('/livekit/token', ensureLiveKitEnv, authenticate, handleLivekitToken);
 
 // Create a new LiveKit room
-// POST /livekit/create-room { name: string }
-app.post('/livekit/create-room', ensureLiveKitEnv, authenticate, async (req, res) => {
+// POST or GET /livekit/create-room { name: string }
+async function handleCreateRoom(req, res) {
   try {
-    const { name } = req.body;
+    const { name } = req.method === 'POST' ? req.body : req.query;
     if (!name) {
       return res.status(400).json({ error: 'name is required' });
     }
@@ -256,12 +258,14 @@ app.post('/livekit/create-room', ensureLiveKitEnv, authenticate, async (req, res
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
-});
+}
+app.post('/livekit/create-room', ensureLiveKitEnv, authenticate, handleCreateRoom);
+app.get('/livekit/create-room', ensureLiveKitEnv, authenticate, handleCreateRoom);
 
 // Join an existing room. If it doesn't exist it will be created.
-// POST /livekit/join-room { room: string, role: 'creator' | 'fan' }
-app.post('/livekit/join-room', ensureLiveKitEnv, authenticate, async (req, res) => {
-  const { room, role } = req.body;
+// POST or GET /livekit/join-room { room: string, role: 'creator' | 'fan' }
+async function handleJoinRoom(req, res) {
+  const { room, role } = req.method === 'POST' ? req.body : req.query;
   if (!room || !role) {
     return res.status(400).json({ error: 'room and role are required' });
   }
@@ -288,7 +292,9 @@ app.post('/livekit/join-room', ensureLiveKitEnv, authenticate, async (req, res) 
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
-});
+}
+app.post('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
+app.get('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
 
 // Fallback: return the frontend's index.html for all other routes to
 // support client-side routing.


### PR DESCRIPTION
## Summary
- allow GET requests on LiveKit token, create-room, and join-room endpoints
- document GET usage for LiveKit routes in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68921b6effe483238d311c31a1106950