### PR TITLE
Fix TypeScript build issues and add new stream flag

### DIFF
--- a/src/components/LiveStreamCard.tsx
+++ b/src/components/LiveStreamCard.tsx
@@ -7,6 +7,13 @@ export interface LiveStreamCardProps {
   streamPreviewUrl: string;
   badge?: 'LIVE' | 'VIP' | 'NEW' | 'TRENDING';
   onWatch?: () => void;
+  /**
+   * Indicates whether the stream is new. Some call sites expect this flag
+   * so we expose it here to avoid TypeScript errors when the property is
+   * provided. When `true` and no explicit badge is supplied, a `NEW` badge
+   * will be displayed.
+   */
+  isNew?: boolean;
 }
 
 const LiveStreamCard: React.FC<LiveStreamCardProps> = ({
@@ -16,6 +23,7 @@ const LiveStreamCard: React.FC<LiveStreamCardProps> = ({
   streamPreviewUrl,
   badge,
   onWatch,
+  isNew,
 }) => {
   const [isVisible, setIsVisible] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
@@ -43,12 +51,17 @@ const LiveStreamCard: React.FC<LiveStreamCardProps> = ({
     return () => observer.disconnect();
   }, []);
 
+  // If `isNew` is set, prefer showing the NEW badge unless another badge
+  // was explicitly provided. This mirrors the expected behaviour in the
+  // Explore page where streams can be marked as new.
+  const resolvedBadge = isNew && !badge ? 'NEW' : badge;
+
   const badgeColor = {
     LIVE: 'bg-red-500',
     VIP: 'bg-purple-500',
     NEW: 'bg-green-500',
     TRENDING: 'bg-yellow-500',
-  }[badge || 'LIVE'];
+  }[resolvedBadge || 'LIVE'];
 
   return (
     <div

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -10,13 +10,14 @@ const mockStreams: Array<LiveStreamCardProps & { id: number }> = [
     badge: 'TRENDING',
     streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
   },
-  {
+  { 
     id: 2,
     username: 'creator2',
     viewerCount: 120,
     avatarUrl: 'https://placekitten.com/201/200',
     badge: 'NEW',
     streamPreviewUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+    isNew: true,
   },
   {
     id: 3,
@@ -41,6 +42,7 @@ const Explore: React.FC = () => {
           viewerCount={s.viewerCount}
           badge={s.badge}
           streamPreviewUrl={s.streamPreviewUrl}
+          isNew={s.isNew}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- extend `LiveStreamCard` props with an optional `isNew` flag and badge resolution
- allow `Explore` page to mark streams as new

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68923a80c9788323bd96bb10cdad4b07