### PR TITLE
fix: send 404 for unknown routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -296,10 +296,9 @@ async function handleJoinRoom(req, res) {
 app.post('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
 app.get('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
 
-// Fallback: return the frontend's index.html for all other routes to
-// support client-side routing.
-app.get('*', (_req, res) => {
-  res.sendFile(path.join(frontendDir, 'index.html'));
+// Return 404 for any other routes.
+app.use((_req, res) => {
+  res.status(404).send('Not Found');
 });
 
 const server = app.listen(port, () => {


### PR DESCRIPTION
## Summary
- return 404 for unmatched routes instead of serving index.html

## Testing
- `npm test`
- `STRIPE_SECRET_KEY=dummy JWT_SECRET=test node server.js &` *(manually verified 404 on `/nonexistent` and terminated server)*

------
https://chatgpt.com/codex/tasks/task_e_6892bbe1a8ac83239aca90c16dc995a2