### PR TITLE
Serve SPA index for client routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -368,6 +368,11 @@ async function handleJoinRoom(req, res) {
 app.post('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
 app.get('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
 
+// Serve the SPA index for any unknown route so client-side routing works.
+app.get('*', (_req, res) =>
+  res.sendFile(path.join(frontendDir, 'index.html'))
+);
+
 // Return 404 for any other routes.
 app.use((_req, res) => {
   res.status(404).send('Not Found');


### PR DESCRIPTION
## Summary
- Serve index.html for unknown routes to avoid 404 on SPA client-side navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895886427088323a16a55a5f7297cd3