### PR TITLE
Serve index.html for client-side routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -368,6 +368,10 @@ async function handleJoinRoom(req, res) {
 app.post('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
 app.get('/livekit/join-room', ensureLiveKitEnv, authenticate, handleJoinRoom);
 
+app.get('*', (_req, res) =>
+  res.sendFile(path.join(frontendDir, 'index.html'))
+);
+
 // Return 404 for any other routes.
 app.use((_req, res) => {
   res.status(404).send('Not Found');


### PR DESCRIPTION
## Summary
- serve index.html for unmatched GET requests to support client-side routing

## Testing
- `npm test`
- `curl -i http://localhost:8080/some`
- `curl -i http://localhost:8080/health`


------
https://chatgpt.com/codex/tasks/task_e_68958dbbede88323998523e1de05196d